### PR TITLE
Fix SKILL.md frontmatter to use valid properties

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: stop-slop
 description: Remove AI writing patterns from prose. Use when drafting, editing, or reviewing text to eliminate predictable AI tells.
-trigger: Writing prose, editing drafts, reviewing content for AI patterns
-author: Hardik Pandya (https://hvpandya.com)
+metadata:
+  trigger: Writing prose, editing drafts, reviewing content for AI patterns
+  author: Hardik Pandya (https://hvpandya.com)
 ---
 
 # Stop Slop


### PR DESCRIPTION
## Summary
- Moves `trigger` and `author` properties under `metadata` in SKILL.md frontmatter
- Resolves the "unexpected key in SKILL.md frontmatter" error on Windows Claude Desktop

## Details
The Claude Desktop app only allows specific frontmatter properties: `name`, `description`, `license`, `allowed-tools`, `compatibility`, and `metadata`. Custom properties like `trigger` and `author` need to be nested under `metadata`.

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)