### PR TITLE
Add Chinese language version (stop-slop-zh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Below 35/50: revise.
 
 [Hardik Pandya](https://hvpandya.com)
 
+## Other Languages
+
+- 🇨🇳 [stop-slop-zh](https://github.com/pencil20388-eng/stop-slop-zh) — Chinese version. Different banned words, punctuation rules, colloquial phrase library, and 4-layer QA system. Chinese AI writing has completely different tells from English.
+
 ## License
 
 MIT. Use freely, share widely.


### PR DESCRIPTION
Added a link to the Chinese version of stop-slop under a new "Other Languages" section.

Chinese AI writing has completely different telltale patterns from English — different filler phrases, punctuation habits (colons, em-dashes), and structural clichés. The Chinese version includes:

- 30+ banned Chinese filler phrases
- Punctuation rules specific to Chinese typography
- 50+ recommended colloquial expressions
- 4-layer quality check system
- Before/after transformation examples

Repo: https://github.com/pencil20388-eng/stop-slop-zh

This is a standalone adaptation, not a translation. MIT licensed.