### PR TITLE
feat: add technical mode with detect-only support for technical documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-05-27
+
+### Added
+
+- **Technical mode** (`references/technical.md`): False-positive guide for API docs, specs, PRDs, ADRs, code comments
+- **Detect-only mode**: Flag issues without rewriting, with structured output
+- **Keep override**: `[keep]` comment to exempt specific lines
+- SKILL.md: Technical mode section with output format
+- README.md: Technical mode quick reference
+
+### Changed
+
+- None. Default behavior unchanged.
+
 ## 2026-01-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ stop-slop/
 
 **Sentence-level rules** - No Wh- sentence starters, no em dashes, no staccato fragmentation, no lazy extremes, active voice required.
 
+## Technical mode
+
+For API docs, specs, PRDs, and code comments:
+
+- Reduces false positives (`robust`, `may`, passive voice, 3+ item lists)
+- Supports `detect` mode (flag only, no rewrite)
+- See `references/technical.md` for false-positive guide
+
+**Use technical mode for technical writing. Use standard mode for everything else.**
+
 ## Scoring
 
 Rate 1-10 on each dimension:

--- a/SKILL.md
+++ b/SKILL.md
@@ -28,6 +28,29 @@ Eliminate predictable AI writing patterns from prose.
 
 8. **Cut quotables.** If it sounds like a pull-quote, rewrite it.
 
+## Technical Mode
+
+For technical documentation (APIs, specs, PRDs, ADRs, code comments), enable technical mode:
+
+or use the `--tech` flag.
+
+When technical mode is enabled:
+
+1. **Reduced sensitivity** on known false positives. See `references/technical.md` for the full guide.
+
+2. **Detect-only mode** (recommended for technical docs):
+
+Flags issues without rewriting. Output format:
+
+
+3. **Keep overrides**: Add `[keep]` on any line to exempt it from rewriting.
+
+### Technical Mode Output Format
+
+### When to Skip Technical Mode
+
+For blog posts, casual writing, marketing copy, or any non-technical prose, keep technical mode OFF. The core Stop Slop rules are correct for these contexts.
+
 ## Quick Checks
 
 Before delivering prose:

--- a/references/technical.md
+++ b/references/technical.md
@@ -1,0 +1,58 @@
+# Technical Writing: False Positive Guide
+
+## When to Use This Guide
+
+This guide applies when writing or reviewing:
+
+- API documentation
+- Technical specifications
+- Product requirements (PRDs)
+- Architecture decision records (ADRs)
+- Code comments and READMEs
+- Configuration guides
+
+For casual/blog prose, ignore this guide. Use the core Stop Slop rules.
+
+## Patterns That Are OK in Technical Docs
+
+| Pattern | When OK | Still Slop in |
+|---------|---------|----------------|
+| `robust`, `comprehensive` | Describing system qualities, test coverage, error handling | Marketing copy, casual prose |
+| `ecosystem` | Describing plugin/extension systems, package managers | Business jargon contexts |
+| `facilitate`, `streamline` | Process descriptions, workflow automation | Casual prose, blog posts |
+| 3+ item lists | API parameters, config options, enum values, dependencies | Narrative prose |
+| Passive voice | Actor unknown ("the data is encrypted"), actor irrelevant ("the request is sent") | Most other contexts |
+| Hedging (`may`, `might`, `typically`) | True uncertainty (platform differences, edge cases) | False modesty, performative humility |
+| `actually` | Correcting a previous statement ("Actually, the method returns an array") | Empty emphasis |
+| `simply` | Describing a straightforward operation ("simply call the method") | Downplaying complexity |
+
+## What to Keep in Technical Writing
+
+- Code blocks, config examples, terminal output
+- Bulleted and numbered specs
+- Tables (not flagged by Stop Slop, but sometimes removed — keep them)
+- Technical accuracy over stylistic purity
+- Domain-specific terminology even if it matches slop patterns
+
+## What to Still Flag (Even in Technical Docs)
+
+| Pattern | Why Still Slop |
+|---------|----------------|
+| Throat-clearing ("Here's the thing about APIs...") | Waste of space |
+| Binary contrasts ("Not because X, because Y") | Predictable |
+| Dramatic fragmentation ("Speed. Quality. Cost.") | Performative |
+| Empty intensifiers ("really", "very", "literally") | No meaning |
+| Narrator-from-a-distance ("Nobody designed this system") | Put the reader in the room |
+| False agency ("The code decides") | Code doesn't decide. A person wrote it. |
+
+## Detecting vs Rewriting
+
+In technical writing, **detect-only mode** is often preferable:
+
+- Terms like "may" are sometimes correct (spec compliance)
+- Passive voice is sometimes required (security docs avoid naming actors)
+- Technical accuracy > stylistic perfection
+
+## How to Override
+
+To keep a flagged phrase without disabling detection globally, add `[keep]` on the same line:


### PR DESCRIPTION
## Problem

Stop Slop is excellent for casual/blog prose but over-fires on technical
documentation (APIs, specs, PRDs, ADRs, code comments).

Specific false positives observed:
- Terms like `robust`, `comprehensive`, `ecosystem`, `facilitate`, `streamline`
- Lists with 3+ items (normal for specs/APIs)
- Passive voice when actor is unknown/irrelevant
- Hedging (`may`, `might`, `typically`) where uncertainty is real

## Solution

Add an **optional technical mode** that:
1. Reduces sensitivity on known false-positive patterns
2. Supports `detect` mode (flag only, no rewrite)
3. Provides `[keep]` overrides for line-by-line exemptions

## Changes

| File | Change |
|------|--------|
| `references/technical.md` | New file - false-positive guide |
| `SKILL.md` | Added Technical Mode section |
| `README.md` | Added technical mode quick reference |
| `CHANGELOG.md` | Added entry |

## Default behavior

**Unchanged.** Technical mode must be explicitly enabled.

## Example

**Input:**
> The API provides robust error handling. It may retry failed requests up to three times.

**Standard Stop Slop (over-fires):**
> The API provides ~~robust~~ error handling. It ~~may~~ retry...

**Technical mode (preserves):**
> Same text. No changes.

---
Ready for review. Happy to iterate.