### PR TITLE
Fix example to avoid em dash

### DIFF
--- a/references/examples.md
+++ b/references/examples.md
@@ -42,7 +42,7 @@
 > "Speed. Quality. Cost. You can only pick two. That's it. That's the tradeoff."
 
 **After:**
-> "Speed, quality, cost—pick two."
+> "Speed, quality, cost; pick two."
 
 **Changes:** Single sentence. No performative emphasis.
 


### PR DESCRIPTION
Example 4's "After" line used an em dash (—), which conflicts with the skill's own guidance (no em dashes).

This swaps it for a semicolon so the example matches the rule without changing intent.