### PR TITLE
feat: add de-sloping prompt library for targeted AI pattern removal

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -28,6 +28,8 @@ Eliminate predictable AI writing patterns from prose.
 
 8. **Cut quotables.** If it sounds like a pull-quote, rewrite it.
 
+9. **Use targeted prompts.** For stubborn patterns, use specific rewrite prompts from [references/prompts.md](references/prompts.md). Each prompt targets one AI slop type.
+
 ## Quick Checks
 
 Before delivering prose:

--- a/references/prompts.md
+++ b/references/prompts.md
@@ -1,0 +1,81 @@
+# De-Sloping Prompt Library
+
+Targeted prompts for removing specific AI patterns from prose. Use these when you spot a particular slop pattern and need a focused rewrite instruction.
+
+## Throat-Clearing Openers
+
+**Pattern:** "In the rapidly evolving landscape of..."
+**Prompt:** Rewrite this sentence to start with the specific claim or fact. Remove the landscape/era/age framing entirely. What is the author actually saying? Lead with that.
+
+**Pattern:** "It is worth noting that..."
+**Prompt:** Delete this phrase. The note follows or it doesn't. If the information matters, state it. If it doesn't, cut it.
+
+**Pattern:** "In today's [X]..."
+**Prompt:** Name the specific year, event, or change instead of "today's." If you can't name it, the sentence is too vague to keep.
+
+**Pattern:** "Let's dive in" / "Let's explore"
+**Prompt:** Remove the announcement. Start with the first actual point.
+
+**Pattern:** "At the end of the day..."
+**Prompt:** State the conclusion directly. This phrase adds zero information.
+
+## Overused Words
+
+**Pattern:** "delve" / "delve into"
+**Prompt:** Replace "delve" with "look at," "examine," "dig into," or "cover" — whichever is most precise. "Delve" is the single most overused AI verb.
+
+**Pattern:** "tapestry" (as metaphor)
+**Prompt:** Name the specific components instead of calling them a tapestry. If you mean "mix," say mix. If you mean "network," say network.
+
+**Pattern:** "crucial" / "paramount" / "pivotal"
+**Prompt:** Replace with the specific consequence of not doing this thing. Why does it matter? State that.
+
+**Pattern:** "comprehensive" / "robust" / "seamless"
+**Prompt:** Delete the adjective. Describe what the thing does, not that it does it well.
+
+**Pattern:** "leverage" / "harness" / "unlock"
+**Prompt:** Replace with "use," "apply," or "enable." These verbs add no meaning.
+
+## Structural Patterns
+
+**Pattern:** "Not X, but Y" contrasts
+**Prompt:** State Y directly. The "not X" part is wasted words unless the reader genuinely assumes X.
+
+**Pattern:** Numbered lists with "First... Second... Third..."
+**Prompt:** Convert to prose with varied transitions, or cut to just two items. Three-item lists are the default AI structure.
+
+**Pattern:** "The [noun] of [noun]" chains
+**Prompt:** Break apart nominalizations. "The implementation of the strategy" → "We implemented the strategy."
+
+**Pattern:** Sentence followed by "This is important because..."
+**Prompt:** Merge the explanation into the original sentence. If the reader needs to be told it's important, the sentence didn't land.
+
+## Filler Transitions
+
+**Pattern:** "Furthermore" / "Moreover" / "Additionally"
+**Prompt:** Delete the transition. Start the next sentence. If the connection isn't clear from context, rewrite the sentence to make it obvious.
+
+**Pattern:** "However" at the start of every other paragraph
+**Prompt:** Vary transitions: "But," "Yet," "Still," "That said," or no transition at all. Or restructure so the contrast is built into the sentence.
+
+**Pattern:** "In conclusion" / "To summarize" / "In summary"
+**Prompt:** Delete. The reader knows the essay is ending. State the final point.
+
+## Vague Authority
+
+**Pattern:** "Studies show..." / "Research suggests..."
+**Prompt:** Name the study, the researcher, the year, or the institution. If you can't, the claim is unverifiable and should be cut.
+
+**Pattern:** "Experts agree..."
+**Prompt:** Name two experts or cut the phrase.
+
+**Pattern:** "It is widely recognized that..."
+**Prompt:** Cite one source or cut the phrase.
+
+## How to Use
+
+1. Identify the slop pattern in the text
+2. Copy the matching prompt
+3. Feed it to the AI (or yourself) alongside the flagged sentence/paragraph
+4. Rewrite using the prompt's instruction
+5. Score the rewrite against the Quick Checks in SKILL.md


### PR DESCRIPTION
## What

Added `references/prompts.md` — a curated library of rewrite prompts that target specific AI slop patterns.

## Why

The existing `phrases.md` tells you *what* to remove. This prompt library tells you *how* to rewrite it. Each prompt includes:

- The pattern to spot
- A specific rewrite instruction

## Categories

- **Throat-clearing openers** — rapidly evolving landscape, worth noting, let's dive in...
- **Overused words** — delve, tapestry, crucial, leverage, comprehensive...
- **Structural patterns** — not X but Y, numbered lists, nominalizations
- **Filler transitions** — furthermore, moreover, however, in conclusion
- **Vague authority** — studies show, experts agree, it is widely recognized

## Changes

- Added `references/prompts.md` with 20+ targeted prompts
- Updated `SKILL.md` Core Rule #9 to reference the new file

Closes #27