### PR TITLE
fix: replace em dash with semicolon in Example 4 to match skill guidelines

### DIFF
--- a/references/examples.md
+++ b/references/examples.md
@@ -42,7 +42,7 @@
 > "Speed. Quality. Cost. You can only pick two. That's it. That's the tradeoff."
 
 **After:**
-> "Speed, quality, cost—pick two."
+> "Speed, quality, cost; pick two."
 
 **Changes:** Single sentence. No performative emphasis.
 


### PR DESCRIPTION
## Summary

Fix Example 4's "After" line to avoid em dash, matching the skill's own guidelines.

## Problem

Example 4 in `references/examples.md` used an em dash (`—`) in the "After" line:

```
"Speed, quality, cost—pick two."
```

This conflicts with the skill's own guidance in `SKILL.md` which bans em dashes as a sentence-level rule.

## Solution

Replace the em dash with a semicolon:

```
"Speed, quality, cost; pick two."
```

The meaning and intent remain identical — this just ensures the example follows the rule it's meant to demonstrate.

## Testing

- Verified the change renders correctly in Markdown
- Confirmed no other em dashes remain in the examples file
- The fix addresses issue #25

## Checklist

- [x] Code follows the project's style guidelines
- [x] Change is minimal and focused
- [x] No breaking changes
- [x] Related issue linked (#25)
