### PR TITLE
Stage 1: define Academic Voice Auditor product scope

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,0 +1,9 @@
+# Attribution
+
+Academic Voice Auditor is based on **Stop Slop**, an original project by **Hardik Pandya**. Stop Slop is distributed under the MIT License, which is retained in this repository in [LICENSE](LICENSE).
+
+Academic Voice Auditor redesigns and extends that project for context-sensitive academic writing review. The current original contribution is primarily the product definition for postgraduate academic writing and the plan to restructure general writing rules around academic conventions, disciplinary differences, hedging, section-specific needs, and protection of authorial meaning.
+
+This repository does not yet contain a completed Python analysis tool, web interface, or evaluated dataset. Its academic rule system also remains under development.
+
+The project does not claim that the underlying idea or inherited material is wholly original to Academic Voice Auditor. Stop Slop and Hardik Pandya must remain credited when this work is used or developed further.

--- a/README.md
+++ b/README.md
@@ -1,62 +1,83 @@
-# Stop Slop
+# Academic Voice Auditor
 
-A skill for removing AI tells from prose.
+A rule-based academic writing auditor that identifies formulaic and generic AI-style writing patterns while preserving academic hedging, disciplinary conventions, appropriate passive voice, and the writer's intended meaning.
 
-<img width="3840" height="2160" alt="G-Yg4RVbIAAhVxW" src="https://github.com/user-attachments/assets/902afc15-1f40-4a9d-af24-8cd67afb8ebf" />
+## Target users
 
-## What this is
+Academic Voice Auditor is intended for international postgraduate students writing coursework or dissertations in English. Stage 1 focuses on writing in education, TESOL, and the social sciences.
 
-AI writing has patterns. Predictable phrases, structures, rhythms. This skill teaches Claude (or any LLM) to catch and remove them.
+## The problem
 
-## Skill Structure
+General-purpose AI writing humanisers often apply absolute rules: remove every adverb, prohibit passive voice, shorten sentences indiscriminately, delete appropriate hedging, or make academic prose sound like marketing copy. These changes can distort meaning, erase disciplinary conventions, or introduce claims the writer did not make.
 
-```
-stop-slop/
-├── SKILL.md              # Core instructions
-├── references/
-│   ├── phrases.md        # Phrases to remove
-│   ├── structures.md     # Structural patterns to avoid
-│   └── examples.md       # Before/after transformations
+Academic conventions vary across disciplines. A useful auditor must therefore consider section, discipline, rhetorical purpose, and intended level of certainty instead of treating every common feature as an error.
+
+## Proposed solution
+
+The planned product will use transparent, rule-based review to flag potentially formulaic or generic patterns for the writer's consideration. It will distinguish potentially unhelpful habits from legitimate academic language, including cautious claims and appropriate passive constructions in Methodology. It will audit rather than blindly rewrite.
+
+## Current scope
+
+The repository currently covers product definition, ethical boundaries, a high-level skill definition, and the structure for a future academic rule system. All analysis, interface, and evaluation capabilities described as future work are **planned**, not implemented.
+
+## Development status
+
+Stage 1: Product definition and repository restructuring
+Status: in progress
+
+The project remains in the product-definition and rule-design stage. There is currently no Python analysis tool, Streamlit application, or web interface. There are no validated accuracy, reliability, or performance results.
+
+## Planned roadmap
+
+- **Stage 1 (in progress):** define the product, boundaries, attribution, and repository structure.
+- **Stage 2 (planned):** review and reclassify inherited patterns; design academic, structural, and section-specific rules.
+- **Later stages (planned):** develop evaluated examples and an evaluation dataset; prototype analysis tooling only after rules and evaluation criteria are reviewed.
+
+Future evaluation is required before making claims about usefulness, reliability, or performance.
+
+## Project structure
+
+```text
+.
+├── ATTRIBUTION.md
+├── CHANGELOG.md
+├── LICENSE
 ├── README.md
-└── LICENSE
+├── SKILL.md
+├── docs/
+│   ├── evaluation_plan.md
+│   ├── product_definition.md
+│   └── rule_design_rationale.md
+├── examples/
+│   ├── findings_example.md
+│   ├── literature_review_example.md
+│   └── methods_example.md
+└── references/
+    ├── academic_phrases.md
+    ├── academic_structures.md
+    ├── do_not_overcorrect.md
+    ├── examples.md
+    ├── generic_patterns.md
+    ├── phrases.md
+    ├── section_specific_rules.md
+    └── structures.md
 ```
 
-## Quick start
+The original reference files—[phrases](references/phrases.md), [structures](references/structures.md), and [examples](references/examples.md)—are retained as source material pending review. They are not the current academic rule set. New Stage 1 reference scaffolds are described in [SKILL.md](SKILL.md).
 
-**Claude Code:** Add this folder as a skill.
+## Attribution
 
-**Claude Projects:** Upload `SKILL.md` and reference files to project knowledge.
+Academic Voice Auditor is a redesign and extension of **Stop Slop**, created by **Hardik Pandya** and released under the MIT License. See [ATTRIBUTION.md](ATTRIBUTION.md) for the full attribution and a clear account of current original contributions.
 
-**Custom instructions:** Copy core rules from `SKILL.md`.
+## Limitations
 
-**API calls:** Include `SKILL.md` in your system prompt. Reference files load on demand.
-
-## What it catches
-
-**Banned phrases** - Throat-clearing openers, emphasis crutches, business jargon, all adverbs, vague declaratives, meta-commentary. See `references/phrases.md`.
-
-**Structural clichés** - Binary contrasts, negative listings, dramatic fragmentation, rhetorical setups, false agency, narrator-from-a-distance voice, passive voice. See `references/structures.md`.
-
-**Sentence-level rules** - No Wh- sentence starters, no em dashes, no staccato fragmentation, no lazy extremes, active voice required.
-
-## Scoring
-
-Rate 1-10 on each dimension:
-
-| Dimension | Question |
-|-----------|----------|
-| Directness | Statements or announcements? |
-| Rhythm | Varied or metronomic? |
-| Trust | Respects reader intelligence? |
-| Authenticity | Sounds human? |
-| Density | Anything cuttable? |
-
-Below 35/50: revise.
-
-## Author
-
-[Hardik Pandya](https://hvpandya.com)
+- This project is not an AI detector and cannot determine whether a person or AI wrote a passage.
+- It does not promise to reduce any AI-detection score and must not be used to evade institutional or platform detection.
+- It must not invent claims, evidence, data, examples, or references.
+- It must preserve intended meaning and appropriate academic caution.
+- Its rule set is incomplete and unevaluated; future evaluation is required.
+- Its initial disciplinary focus is limited, and academic conventions vary across disciplines.
 
 ## License
 
-MIT. Use freely, share widely.
+This project retains the original [MIT License](LICENSE). See [ATTRIBUTION.md](ATTRIBUTION.md) for origin and contribution details.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,68 +1,32 @@
 ---
-name: stop-slop
-description: Remove AI writing patterns from prose. Use when drafting, editing, or reviewing text to eliminate predictable AI tells.
-metadata:
-  trigger: Writing prose, editing drafts, reviewing content for AI patterns
-  author: Hardik Pandya (https://hvpandya.com)
+name: academic-voice-auditor
+description: Audit postgraduate academic writing for formulaic and generic AI-style patterns while preserving intended meaning, appropriate hedging, disciplinary conventions, and legitimate passive voice. Use when reviewing academic prose in education, TESOL, or the social sciences without acting as an AI detector or inventing content, evidence, or citations.
 ---
 
-# Stop Slop
+# Academic Voice Auditor
 
-Eliminate predictable AI writing patterns from prose.
+Audit academic prose using context-sensitive, rule-based guidance. Preserve the writer's intended meaning and level of certainty.
 
-## Core Rules
+## Core boundaries
 
-1. **Cut filler phrases.** Remove throat-clearing openers, emphasis crutches, and all adverbs. See [references/phrases.md](references/phrases.md).
+- Do not claim to determine whether text was written by a person or AI.
+- Do not promise to reduce AI-detection scores or help evade detection.
+- Do not invent claims, evidence, data, references, citations, or examples.
+- Respect disciplinary and section-specific conventions.
+- Do not automatically treat passive voice, adverbs, hedging, or common academic phrases as errors.
+- Preserve appropriate passive voice, especially where it serves Methodology conventions.
+- Do not convert academic prose into marketing or social-media copy.
 
-2. **Break formulaic structures.** Avoid binary contrasts, negative listings, dramatic fragmentation, rhetorical setups, false agency. See [references/structures.md](references/structures.md).
+## Stage 1 workflow
 
-3. **Use active voice.** Every sentence needs a human subject doing something. No passive constructions. No inanimate objects performing human actions ("the complaint becomes a fix").
+1. Identify the academic section and disciplinary context when they are available.
+2. Consult [do-not-overcorrect principles](references/do_not_overcorrect.md) before suggesting changes.
+3. Treat [generic patterns](references/generic_patterns.md), [academic phrases](references/academic_phrases.md), [academic structures](references/academic_structures.md), and [section-specific rules](references/section_specific_rules.md) as Stage 1 design scaffolds, not a complete validated rule set.
+4. Explain the reason for a flag and leave the final wording decision with the writer.
+5. Avoid unsupported additions and preserve the claim's original strength.
 
-4. **Be specific.** No vague declaratives ("The reasons are structural"). Name the specific thing. No lazy extremes ("every," "always," "never") doing vague work.
+The inherited [phrases](references/phrases.md), [structures](references/structures.md), and [examples](references/examples.md) remain source material for Stage 2 review. Do not apply their absolute rules uncritically in academic contexts.
 
-5. **Put the reader in the room.** No narrator-from-a-distance voice. "You" beats "People." Specifics beat abstractions.
+## Development boundary
 
-6. **Vary rhythm.** Mix sentence lengths. Two items beat three. End paragraphs differently. No em dashes.
-
-7. **Trust readers.** State facts directly. Skip softening, justification, hand-holding.
-
-8. **Cut quotables.** If it sounds like a pull-quote, rewrite it.
-
-## Quick Checks
-
-Before delivering prose:
-
-- Any adverbs? Kill them.
-- Any passive voice? Find the actor, make them the subject.
-- Inanimate thing doing a human verb ("the decision emerges")? Name the person.
-- Sentence starts with a Wh- word? Restructure it.
-- Any "here's what/this/that" throat-clearing? Cut to the point.
-- Any "not X, it's Y" contrasts? State Y directly.
-- Three consecutive sentences match length? Break one.
-- Paragraph ends with punchy one-liner? Vary it.
-- Em-dash anywhere? Remove it.
-- Vague declarative ("The implications are significant")? Name the specific implication.
-- Narrator-from-a-distance ("Nobody designed this")? Put the reader in the scene.
-- Meta-joiners ("The rest of this essay...")? Delete. Let the essay move.
-
-## Scoring
-
-Rate 1-10 on each dimension:
-
-| Dimension | Question |
-|-----------|----------|
-| Directness | Statements or announcements? |
-| Rhythm | Varied or metronomic? |
-| Trust | Respects reader intelligence? |
-| Authenticity | Sounds human? |
-| Density | Anything cuttable? |
-
-Below 35/50: revise.
-
-## Examples
-
-See [references/examples.md](references/examples.md) for before/after transformations.
-
-## License
-
-MIT
+Do not infer or supply the complete Stage 2 rule library. Academic conventions vary across disciplines, and future rule design and evaluation are required.

--- a/docs/evaluation_plan.md
+++ b/docs/evaluation_plan.md
@@ -1,0 +1,9 @@
+# Evaluation Plan
+
+## Purpose
+
+This file will define how future rules and outputs should be evaluated without treating the project as an AI detector or claiming unverified performance.
+
+## Stage 2 work
+
+Stage 2 will specify evaluation questions, example-selection principles, reviewer criteria, annotation guidance, meaning-preservation checks, error categories, and reporting requirements. No evaluation results, accuracy claims, user-study findings, or completed dataset are provided at Stage 1.

--- a/docs/product_definition.md
+++ b/docs/product_definition.md
@@ -1,0 +1,96 @@
+# Product Definition
+
+## 1. Product overview
+
+Academic Voice Auditor is a planned rule-based academic writing auditor for international postgraduate students. It will identify formulaic and generic AI-style writing patterns while preserving academic hedging, disciplinary conventions, appropriate passive voice, and the writer's intended meaning. It is an editing aid, not an AI detector or an automatic humaniser.
+
+## 2. Target users
+
+The primary users are international postgraduate students who write coursework or dissertations in English. The first disciplinary focus is education, TESOL, and social science academic writing.
+
+## 3. User problem
+
+Writers need help identifying generic, repetitive, or formulaic language without losing precision, appropriate caution, disciplinary terminology, or authorial intent. A blanket rewrite may make a passage shorter or more conversational while making it less academically suitable.
+
+## 4. Current alternatives
+
+Current alternatives include general grammar checkers, style checkers, generative rewriting assistants, AI writing humanisers, writing-centre guidance, supervisor feedback, and discipline-specific academic writing resources.
+
+## 5. Limitations of current alternatives
+
+Automated alternatives may use broad rules that remove all adverbs, reject all passive voice, shorten sentences regardless of function, erase justified hedging, strengthen cautious claims, or shift academic prose toward marketing language. They may also obscure why a change was suggested. Human feedback is valuable but may be limited by time and availability.
+
+Academic conventions vary across disciplines, so a general style preference cannot safely be treated as a universal academic rule.
+
+## 6. Proposed solution
+
+Develop a transparent, rule-based auditor that flags candidate patterns, explains their possible effect, accounts for section and disciplinary context, and lets the writer decide whether revision is appropriate. The system should distinguish a potentially generic pattern from a legitimate academic convention rather than applying automatic deletion or replacement.
+
+## 7. Core value proposition
+
+Provide academically sensitive review that helps writers notice formulaic language without changing their intended meaning, certainty, evidence base, or disciplinary voice.
+
+## 8. In-scope features
+
+The following capabilities are planned and require further design and evaluation:
+
+- Rule-based flags for selected generic and formulaic patterns.
+- Explanations rather than unexplained automatic corrections.
+- Protection for appropriate hedging and claim strength.
+- Context-sensitive handling of passive voice, including Methodology use.
+- Section-specific guidance for Literature Review, Methodology, Findings, Discussion, and general academic writing.
+- An initial focus on education, TESOL, and social sciences.
+
+## 9. Out-of-scope features
+
+- Determining whether a human or AI wrote a passage.
+- Predicting, guaranteeing, or optimising AI-detection scores.
+- Helping users evade institutional or platform detection.
+- Inventing or supplying unsupported claims, evidence, data, citations, references, or examples.
+- Replacing disciplinary expertise, supervisor feedback, or institutional academic-integrity guidance.
+- Turning academic work into marketing or social-media copy.
+
+## 10. Risks
+
+- Overcorrection could alter meaning, certainty, or academic voice.
+- Rules may encode assumptions that do not transfer across disciplines, genres, institutions, or varieties of English.
+- Writers may interpret a flag as a prohibition rather than a prompt for judgement.
+- Inherited general-writing rules may be unsuitable for academic prose.
+- Users may mistake the product for an AI detector or detection-evasion tool.
+- A narrow initial corpus or evaluation design could produce misleading conclusions.
+
+## 11. Ethical boundaries
+
+The product must not classify authorship, claim detection capability, facilitate detection evasion, or guarantee score changes. It must preserve intended meaning and must not fabricate content, data, references, evidence, or examples. It must allow legitimate hedging, passive voice, disciplinary terminology, and section-specific conventions. Suggestions must remain transparent and contestable.
+
+## 12. Initial success criteria
+
+These are proposed future evaluation criteria, not achieved results:
+
+- Writers and qualified reviewers judge that suggested revisions generally preserve intended meaning and claim strength.
+- The auditor distinguishes selected generic patterns from legitimate hedging and appropriate passive voice in a reviewed evaluation set.
+- Explanations help reviewers understand why a passage was flagged and when no change is needed.
+- Error analysis is reported by discipline and section rather than only as an aggregate measure.
+- The product communicates its non-detector status and ethical boundaries clearly to users.
+
+Future evaluation is required before thresholds, benchmarks, or performance claims can be established.
+
+## 13. Assumptions requiring validation
+
+- Target users find rule explanations more useful than unexplained rewrites.
+- A shared rule framework can support education, TESOL, and selected social science writing without erasing meaningful disciplinary variation.
+- Section labels provide enough context to improve handling of passive voice, hedging, and rhetorical structure.
+- Users can distinguish advisory flags from mandatory corrections when the interface and explanations are clear.
+- Representative, ethically sourced examples can be assembled for evaluation.
+
+No user interviews, study findings, accuracy figures, or performance data are claimed at this stage. Future evaluation is required.
+
+## 14. Open questions
+
+- Which patterns should be flagged, permitted, or treated as context dependent?
+- How should rules differ across disciplines, assignment types, and academic sections?
+- What evidence and reviewer qualifications should support rule inclusion?
+- How should disagreements between reviewers be documented?
+- What user controls are needed to protect meaning and claim strength?
+- Which evaluation measures best capture usefulness without implying AI-authorship detection?
+- How should the project communicate uncertainty and rule limitations in a future interface?

--- a/docs/rule_design_rationale.md
+++ b/docs/rule_design_rationale.md
@@ -1,0 +1,9 @@
+# Rule Design Rationale
+
+## Purpose
+
+This file will document why academic writing rules are included, excluded, or made context dependent, with particular attention to meaning, hedging, passive voice, disciplinary variation, and section-specific conventions.
+
+## Stage 2 work
+
+Stage 2 will review and reclassify inherited Stop Slop patterns, define evidence requirements for new rules, document exceptions and overcorrection risks, and establish a rationale for each proposed academic rule. No complete rule set or validated conclusions are provided at Stage 1.

--- a/examples/findings_example.md
+++ b/examples/findings_example.md
@@ -1,0 +1,7 @@
+# Findings Example
+
+## Purpose
+
+Demonstrate future context-sensitive review of a Findings passage without inventing interpretation or evidence.
+
+Example content will be developed and evaluated in a later stage.

--- a/examples/literature_review_example.md
+++ b/examples/literature_review_example.md
@@ -1,0 +1,7 @@
+# Literature Review Example
+
+## Purpose
+
+Demonstrate future context-sensitive review of a literature review passage.
+
+Example content will be developed and evaluated in a later stage.

--- a/examples/methods_example.md
+++ b/examples/methods_example.md
@@ -1,0 +1,7 @@
+# Methods Example
+
+## Purpose
+
+Demonstrate future context-sensitive review of a Methodology passage, including appropriate passive voice.
+
+Example content will be developed and evaluated in a later stage.

--- a/references/academic_phrases.md
+++ b/references/academic_phrases.md
@@ -1,0 +1,20 @@
+# Academic Phrases
+
+## Purpose
+
+Provide a future reference for reviewing academic phrases without treating frequency or familiarity as proof of poor writing or AI authorship.
+
+## Scope
+
+The reference will focus initially on education, TESOL, and social science writing while recognising disciplinary variation and rhetorical context.
+
+## Rule categories to design
+
+- Formulaic framing and transitions
+- Legitimate academic hedging
+- Claim-strength and certainty markers
+- Reporting and attribution language
+- Section-sensitive academic phrases
+- Discipline-specific terminology and conventional phrasing
+
+The complete rules will be designed in Stage 2.

--- a/references/academic_structures.md
+++ b/references/academic_structures.md
@@ -1,0 +1,20 @@
+# Academic Structures
+
+## Purpose
+
+Provide a future reference for reviewing potentially formulaic structures while preserving coherent academic argument and genre conventions.
+
+## Scope
+
+The reference will address sentence, paragraph, and argument structures in education, TESOL, and social science writing, with attention to disciplinary and section-specific differences.
+
+## Rule categories to design
+
+- Paragraph and argument organisation
+- Evidence-to-claim relationships
+- Repetition and parallel structure
+- Contrast and synthesis structures
+- Sentence rhythm and information density
+- Section-specific rhetorical moves
+
+The complete rules will be designed in Stage 2.

--- a/references/do_not_overcorrect.md
+++ b/references/do_not_overcorrect.md
@@ -1,0 +1,12 @@
+# Do Not Overcorrect
+
+- Preserve the writer's intended meaning.
+- Do not invent claims, evidence, references or examples.
+- Do not automatically remove academic hedging.
+- Do not automatically remove passive voice.
+- Do not convert academic prose into marketing copy.
+- Do not replace precise disciplinary terminology with casual vocabulary.
+- Do not strengthen a cautious claim into a definite claim.
+- Do not shorten sentences only to make them sound punchier.
+- Do not treat every common academic phrase as evidence of AI writing.
+- Preserve legitimate disciplinary conventions.

--- a/references/generic_patterns.md
+++ b/references/generic_patterns.md
@@ -1,0 +1,7 @@
+# Generic Patterns
+
+## Purpose
+
+This file will contain academically relevant classifications of formulaic and generic writing patterns.
+
+The original Stop Slop general rules will be audited and reclassified in a later stage. They must not be copied wholesale or applied automatically because some may conflict with legitimate academic conventions. Stage 2 will decide which patterns are relevant, context dependent, unsupported, or unsuitable for academic writing.

--- a/references/section_specific_rules.md
+++ b/references/section_specific_rules.md
@@ -1,0 +1,13 @@
+# Section-Specific Rules
+
+Specific judgement rules will be developed in Stage 2.
+
+## Literature Review
+
+## Methodology
+
+## Findings
+
+## Discussion
+
+## General Academic Writing


### PR DESCRIPTION
## Summary

This pull request completes Stage 1 of the Academic Voice Auditor redesign.

## Changes

- Repositioned the project for international postgraduate academic writing
- Added product definition and ethical boundaries
- Added attribution to Stop Slop and Hardik Pandya
- Created scaffolding for academic and section-specific rules
- Preserved the original MIT License and source reference files

## Current status

This stage covers product definition and repository restructuring only.

Python tooling, a web interface, evaluation data, and the complete academic rule library are not yet implemented.